### PR TITLE
Fix/issues/7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>com.github.ppadial</groupId>
   <artifactId>testrail-api-client</artifactId>
-  <version>0.4.1-SNAPSHOT</version>
+  <version>0.4.2-SNAPSHOT</version>
 
   <name>Testrail api client for Java</name>
   <description>A testrail API client for java projects</description>

--- a/src/main/java/com/github/ppadial/testrail/client/api/plans/PlanServiceClient.java
+++ b/src/main/java/com/github/ppadial/testrail/client/api/plans/PlanServiceClient.java
@@ -91,7 +91,7 @@ public final class PlanServiceClient extends TestRailServiceBase {
    * Get all test plans of a project with a filter.
    *
    * @param projectId project identifier
-   * @param filters filters to apply
+   * @param filters filters to apply. See possible parameters: {@code = http://docs.gurock.com/testrail-api2/reference-plans#get_plans}
    * @return list of test plans from the specified project that meets the filter
    * @throws TestRailException An error in the connection with testrail
    * @since 0.1.0
@@ -110,7 +110,7 @@ public final class PlanServiceClient extends TestRailServiceBase {
     }
 
     // Do the query
-    apiResponse = get("get_plans/" + projectId);
+    apiResponse = get(url);
 
     Map<HttpStatusCode, TestRailException> choices =
         new HashMap<HttpStatusCode, TestRailException>() {

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRCase.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRCase.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class TRCase extends CustomFieldsEntity {
 
-  public int id;
+  public Integer id;
   public String title;
   @JsonProperty("suite_id")
   public int suiteId;

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRCaseField.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRCaseField.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TRCaseField {
 
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_default")
   public Boolean isDefault;
   @JsonProperty("name")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRCaseType.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRCaseType.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TRCaseType {
 
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_default")
   public Boolean isDefault;
   @JsonProperty("name")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRMilestone.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRMilestone.java
@@ -54,7 +54,7 @@ public class TRMilestone {
    * The unique ID of the milestone.
    */
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   /**
    * True if the milestone is marked as completed and false otherwise.
    */

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRPlan.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRPlan.java
@@ -78,7 +78,7 @@ public class TRPlan {
    * The unique ID of the test plan.
    */
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   /**
    * True if the test plan was closed and false otherwise.
    */

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRPlanEntry.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRPlanEntry.java
@@ -38,7 +38,7 @@ public class TRPlanEntry {
   @JsonProperty("suite_id")
   public int suiteId;
   public String name;
-  public List<TRRun> TRRuns;
+  public List<TRRun> runs;
   @JsonProperty("assignedto_id")
   public Integer assignedTo;
   @JsonProperty("include_all")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRPriority.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRPriority.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TRPriority {
 
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_default")
   public Boolean isDefault;
   @JsonProperty("name")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRResult.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRResult.java
@@ -67,7 +67,7 @@ public class TRResult {
    * The unique ID of the test result.
    */
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   /**
    * The status of the test result, e.g. passed or failed, also see get_statuses.
    */

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRSection.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRSection.java
@@ -31,7 +31,7 @@ package com.github.ppadial.testrail.client.model;
  */
 public class TRSection {
 
-  public int id;
+  public Integer id;
   public String name;
   public int depth;
   public int parent_id;

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRStatus.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRStatus.java
@@ -50,7 +50,7 @@ public class TRStatus {
   @JsonProperty("color_medium")
   public Long colorMedium;
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_final")
   public Boolean isFinal;
   @JsonProperty("is_system")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRSuite.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRSuite.java
@@ -47,7 +47,7 @@ public final class TRSuite {
    * The unique ID of the test suite.
    */
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   /**
    * True if the test suite is a baseline test suite and false otherwise (added with TestRail 4.0).
    */

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRTemplate.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRTemplate.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class TRTemplate {
 
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_default")
   public Boolean is_default;
   @JsonProperty("name")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRTest.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRTest.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class TRTest {
 
-  public int id;
+  public Integer id;
   @JsonProperty("case_id")
   public int caseId;
   @JsonProperty("statusId")

--- a/src/main/java/com/github/ppadial/testrail/client/model/TRUser.java
+++ b/src/main/java/com/github/ppadial/testrail/client/model/TRUser.java
@@ -37,7 +37,7 @@ public class TRUser {
   @JsonProperty("email")
   public String email;
   @JsonProperty("id")
-  public int id;
+  public Integer id;
   @JsonProperty("is_active")
   public Boolean is_active;
   @JsonProperty("name")


### PR DESCRIPTION
Multiple fixes:

Fix filters for getPlans();
Add getRuns() methods;
All Ids in POJOs are Integer except TRPlanEntry.java;
TRPlanEntry.java: property name TRRuns -> runs. It fixes parser auto-matching.